### PR TITLE
Add nix packaging with flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763835633,
+        "narHash": "sha256-HzxeGVID5MChuCPESuC0dlQL1/scDKu+MmzoVBJxulM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "050e09e091117c3d7328c7b2b7b577492c43c134",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Nix flake for the cinecli Python CLI";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems =
+        f:
+        builtins.listToAttrs (
+          map (system: {
+            name = system;
+            value = f system;
+          }) systems
+        );
+
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          cinecli = pkgs.python3Packages.buildPythonPackage {
+            pname = "cinecli";
+            version = "flake";
+            src = self;
+
+            propagatedBuildInputs = with pkgs.python3Packages; [
+              requests
+              rich
+              typer
+            ];
+
+            pyproject = true;
+            build-system = with pkgs.python3Packages; [
+              setuptools
+              wheel
+            ];
+
+          };
+
+          default = self.packages.${system}.cinecli;
+        }
+      );
+    };
+}


### PR DESCRIPTION
Thanks for this  small utility, I wanted to test it, but since I use nix, so it is more convenient to have nix packaging for managing the software.

With this flake and nix installed https://nixos.org/ 

you are able to install the package directly from github:

**nix profile add github:eyeblech/cinecli**

or run it without installing it permamently:

**nix run github:eyeblech/cinecli**

This may help people test the software with less friction. Cool demo here, tested it with public-domain movies.