### PR TITLE
Support for downloading using transmission-rpc

### DIFF
--- a/cinecli/__main__.py
+++ b/cinecli/__main__.py
@@ -1,0 +1,3 @@
+from .cli import app
+
+app()

--- a/cinecli/cli.py
+++ b/cinecli/cli.py
@@ -87,6 +87,8 @@ def watch(movie_id: int):
 
 
     default_action = config.get("default_action", "magnet")
+    transmission = config.get("transmission", {})
+    open_method = "Transmission client" if transmission.get("enable", False) else "web browser"
 
     action = Prompt.ask(
         "Choose action",
@@ -100,12 +102,11 @@ def watch(movie_id: int):
             torrent["hash"],
             f"{movie['title']} {torrent['quality']}",
         )
-        open_magnet(magnet)
-        console.print("[green]🧲 Magnet link opened in your torrent client![/green]")
+        open_magnet(magnet, transmission)
+        console.print(f"[green]🧲 Magnet link opened in your {open_method}![/green]")
     else:
-        download_torrent(torrent["url"])
-        console.print("[green]⬇ Torrent file download started in browser.[/green]")
-
+        download_torrent(torrent["url"], transmission)
+        console.print(f"[green]⬇ Torrent file download started in your {open_method}.[/green]")
 # -------------------------------------------------
 # Interactive command
 # -------------------------------------------------

--- a/cinecli/magnets.py
+++ b/cinecli/magnets.py
@@ -1,5 +1,6 @@
 import webbrowser
 import urllib.parse
+from transmission_rpc import Client
 
 TRACKERS = [
     "udp://open.demonii.com:1337/announce",
@@ -13,11 +14,17 @@ def build_magnet(hash_: str, name: str) -> str:
     dn = urllib.parse.quote(name)
     return f"magnet:?xt=urn:btih:{hash_}&dn={dn}{trackers}"
 
-def open_magnet(magnet_url: str):
-    webbrowser.open(magnet_url)
+def open_magnet(magnet_url: str, transmission: dict = {}):
+    download_torrent(magnet_url, transmission)
 
-def download_torrent(torrent_url: str):
-    webbrowser.open(torrent_url)
+def download_torrent(url: str, transmission: dict = {}):
+    if transmission.get("enable", False):
+        client_options = { k : v for k, v in transmission.items() if k != "enable" }
+        Client(**client_options).add_torrent(url)
+    else:
+        webbrowser.open(url)
+
+
 def select_best_torrent(torrents: list[dict]) -> dict:
     """
     Pick the torrent with the highest quality and seeds.

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
               requests
               rich
               typer
+              transmission-rpc
             ];
 
             pyproject = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ authors = [
 dependencies = [
   "typer>=0.9",
   "rich>=13.0",
-  "requests>=2.28"
+  "requests>=2.28",
+  "transmission-rpc>=7.0",
 ]
 
 keywords = [


### PR DESCRIPTION
Support for downloading using a transmission server, using [transmission-rpc](https://transmission-rpc.readthedocs.io/).

To activate you add this to your `~/.config/cinecli/config.toml`:

```toml
[transmission]
enable = true
# extra options for transmission_rpc.Client, for example
# host = "localhost"
# port = "9091"
```