### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,6 @@ Built by **eyeblech**
 
 ## ⭐ Star History
 
-[![Star History](https://api.star-history.com/svg?repos=eyeblech/cinecli&type=Date&v=1)](https://star-history.com/#eyeblech/cinecli)
+[![Star History](https://star-history.dera.page/svg?repos=eyeblech/cinecli&type=Date&v=1)](https://star-history.dera.page/#eyeblech/cinecli)
 
 


### PR DESCRIPTION
The star history chart in the README is currently broken and renders blank, since the underlying data source no longer works reliably. This switches the chart to a working provider so the image displays correctly again.